### PR TITLE
Update CI 02 2025 

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.64.0
+        pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install h5py

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Linux an
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-compiler:
-    description: "gcc9 apple-clang"
+    description: "gcc apple-clang"
     required: true
   conan-cc:
     description: "gcc clang"
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 5 6 7 8 9 ] [clang: 39 40 50 60 7 8 9] [10.0]"
+    description: "A number [gcc: 5 6 7 8 9 10 11 12 13 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Windows,
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-visual-version:
-    description: "MSVC version: 15, 16 represent msvc-2017 or msvc-2019"
+    description: "MSVC version: 16, 17 represent msvc-2019 and msvc-2022"
     required: true
   conan-visual-runtime:
     description: "MD or MDd"

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.64.0
+        pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install h5py

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -54,7 +54,6 @@ runs:
       run: |
         for /f "delims=" %%i in ('where cmake') do set CONAN_CMAKE_PROGRAM="%%i"
         set CONAN_USER_HOME=%cd%\_conan
-        set VS160COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools"
 
         echo Add LKEB artifactory as remote at URL: %CONAN_UPLOAD%
         conan remote add %CONAN_LKEB_ARTIFACTORY% %CONAN_UPLOAD%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,15 +41,6 @@ jobs:
             build-runtime: MD
             build-config: Release
            
-          # GLIBC >= 2.28
-          - name: Linux_gcc11
-            os: ubuntu-20.04
-            build-compiler: gcc
-            build-cversion: 10
-            build-config: Release
-            build-os: Linux
-            build-libcxx: libstdc++11
-
           - name: Linux_gcc11
             os: ubuntu-22.04
             build-cc: gcc
@@ -60,14 +51,15 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++11
 
-          - name: Macos_xcode13.4
-            os: macos-12
-            build-compiler: apple-clang
+          - name: Linux_gcc13
+            os: ubuntu-24.04
+            build-cc: gcc
+            build-cxx: g++
+            build-compiler: gcc
             build-cversion: 13
             build-config: Release
-            build-os: Macos
-            build-xcode-version: 13.4
-            build-libcxx: libc++
+            build-os: Linux
+            build-libcxx: libstdc++11
 
           - name: Macos_xcode14.3
             os: macos-13
@@ -87,9 +79,18 @@ jobs:
             build-xcode-version: 15.4
             build-libcxx: libc++
   
+          - name: Macos_xcode16
+            os: macos-15
+            build-compiler: apple-clang
+            build-cversion: 16
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 16.2
+            build-libcxx: libc++
+  
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -112,7 +113,7 @@ jobs:
           platform: x64
 
       - name: Windows build
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(matrix.os, 'ubuntu')
         uses: ./.github/conan_windows_build
         with:
           conan-visual-version: ${{matrix.build-cversion}}
@@ -121,8 +122,20 @@ jobs:
           conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
 
-      - name: Linux Mac build
+      - name: Mac build
         if: "!startsWith(runner.os, 'Windows')"
+        uses: ./.github/conan_linuxmac_build
+        with:
+          conan-compiler: ${{matrix.build-compiler}}
+          conan-compiler-version: ${{matrix.build-cversion}}
+          conan-libcxx-version: ${{matrix.build-libcxx}}
+          conan-build-type: ${{matrix.build-config}}
+          conan-build-os: ${{matrix.build-os}}
+          conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
+          conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
+
+      - name: Linux build
+        if: startsWith(matrix.os, 'macOS')
         uses: ./.github/conan_linuxmac_build
         with:
           conan-compiler: ${{matrix.build-compiler}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           platform: x64
 
       - name: Windows build
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'windows')
         uses: ./.github/conan_windows_build
         with:
           conan-visual-version: ${{matrix.build-cversion}}
@@ -122,8 +122,8 @@ jobs:
           conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
 
-      - name: Mac build
-        if: "!startsWith(runner.os, 'Windows')"
+      - name: Linux build
+        if: startsWith(matrix.os, 'ubuntu')
         uses: ./.github/conan_linuxmac_build
         with:
           conan-compiler: ${{matrix.build-compiler}}
@@ -134,7 +134,7 @@ jobs:
           conan-user: ${{secrets.LKEB_ARTIFACTORY_USER}}
           conan-password: ${{secrets.LKEB_ARTIFACTORY_PASSWORD}}
 
-      - name: Linux build
+      - name: Mac build
         if: startsWith(matrix.os, 'macOS')
         uses: ./.github/conan_linuxmac_build
         with:

--- a/conanfile.py
+++ b/conanfile.py
@@ -224,6 +224,10 @@ message(STATUS "OpenMP library: $<$<LINK_LANGUAGE:CXX>:${OpenMP_CXX_LIBRARIES}> 
         cmake_debug.install(build_type="Debug")
 
         cmake_release = self._configure_cmake()
+        cmake_release.build(build_type="RelWithDebInfo")
+        cmake_release.install(build_type="RelWithDebInfo")
+        
+        cmake_release = self._configure_cmake()
         cmake_release.build(build_type="Release")
         cmake_release.install(build_type="Release")
 
@@ -265,5 +269,7 @@ message(STATUS "OpenMP library: $<$<LINK_LANGUAGE:CXX>:${OpenMP_CXX_LIBRARIES}> 
 
         # Debug
         self._pkg_bin("Debug")
+        # RelWithDebInfo
+        self._pkg_bin("RelWithDebInfo")
         # Release
         self._pkg_bin("Release")

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from pathlib import Path
 
-required_conan_version = ">=1.51.0"
+required_conan_version = ">=1.66.0"
 
 
 class FlannDualConan(ConanFile):


### PR DESCRIPTION
- Remove `ubuntu-20.04`
- Remove `macos-12`
- Add `ubuntu-24.04`
- Add `macos-15` (XCode 16.2, ARM)
- Add `RelWithDebInfo` build

See https://github.com/actions/runner-images/issues/10721
> The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24 for GitHub and by 01/13/25 for ADO

See https://github.com/actions/runner-images/issues/11101
> The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01 

Also: update conan to [1.66 which adds new apple-clang 16](https://github.com/conan-io/conan/releases/tag/1.66.0) (Otherwise adding `macos-15` (XCode 16.2) won't compile)
- **Caution**: I think this will require downstream repos (i.e. HDILib) to also upgrade their conan version